### PR TITLE
External custom item width height

### DIFF
--- a/src/components/apps/external/ExternalApp.vue
+++ b/src/components/apps/external/ExternalApp.vue
@@ -167,8 +167,6 @@ export default {
 
 .favoriteImgContainer {
     position: relative;
-    width: 180px;
-    height: 100px;
     border-radius: 8px;
     border-width: 1px;
     border-style: solid;

--- a/src/components/apps/external/ExternalApp.vue
+++ b/src/components/apps/external/ExternalApp.vue
@@ -34,7 +34,13 @@
                         :key="item.title"
                         :class="$style.favorite"
                     >
-                        <div :class="$style.favoriteImgContainer">
+                        <div
+                            :class="$style.favoriteImgContainer"
+                            :style="{
+                                width: `${item.width || 180}px`,
+                                height: `${item.height || 100}px`,
+                            }"
+                        >
                             <img
                                 v-if="item.imgUrl"
                                 :src="getImgUrl(item.imgUrl)"


### PR DESCRIPTION
Allows using `width` and `height` properties (in px units) for items in the Favorites app in the external data.json file.